### PR TITLE
Support Docker Swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ services:
 * **WEBROOT_PATH** Path to the letsencrypt directory in the web server for checks. Defaults to `/var/www`.
 * **CERTS_PATH**: Optional. Copy the new certificates to the specified path. e.g. `/etc/nginx/certs`.
 * **SERVER_CONTAINER**: Optional. The Docker container name of the server you wish to send a `HUP` signal to in order to reload its configuration and use the new certificates.
+* **SERVER_CONTAINER_LABEL**: Optional. The Docker container label of the server you wish to send a `HUP` signal to in order to reload its configuration and use the new certificates. This environment variable will be helpfull in case of deploying with docker swarm since docker swarm will create container name itself.
 * **CHECK_FREQ**: How often (in days) to perform checks. Defaults to `30`.
 
 #### License

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,13 @@ check() {
     eval docker kill -s HUP $SERVER_CONTAINER
   fi
 
+  if [ "$SERVER_CONTAINER_LABEL" ]; then
+    echo "* Reloading Nginx configuration for label $SERVER_CONTAINER_LABEL"
+
+    container_id=`docker ps --filter label=$SERVER_CONTAINER_LABEL -q`
+    eval docker kill -s HUP $container_id
+  fi
+
   echo "* Next check in $CHECK_FREQ days"
   sleep ${CHECK_FREQ}d
   check


### PR DESCRIPTION
Since docker swarm will create container name itself, the SERVER_CONTAINER environment variable cannot be used. I add another environment variable, SERVER_CONTAINER_LABEL, to help with deployment in docker swarm.

Usage Example: 

```
version: "3"

services:
  nginx:
      restart: on-failure
      volumes:
          - acme:/var/www
          - certs:/etc/letsencrypt
      labels:
          - nginx

  letsencrypt:
      depends_on:
          - nginx
      volumes:
          - /var/run/docker.sock:/var/run/docker.sock
          - certs:/etc/letsencrypt
          - acme:/var/www
      environment:
          EMAIL: "support@example.com"
          SERVER_CONTAINER_LABEL: "nginx"
          WEBROOT_PATH: "/var/www"
          DOMAINS: "example.com"
          CHECK_FREQ: 7
      restart: unless-stopped

volumes:
    certs:
    acme:

```